### PR TITLE
Add PUB400 integration instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Sample environment file for IBM i connection
+# Copy this to .env and fill in your credentials
+Host=PUB400.COM
+user=YOUR_USER_PROFILE
+password=YOUR_PASSWORD

--- a/Python_Scripts/Ftp_IBM_System_i.py
+++ b/Python_Scripts/Ftp_IBM_System_i.py
@@ -5,8 +5,10 @@
 #*************************************************************************************
 #  -*- coding: utf-8 -*-
 from ftplib import FTP
+from decouple import config
+
 ftp = FTP()
-ftp.connect('xx.xx.xxx.xx or Host_name' , 21, -999) 
-ftp.login('USER_PROFILE', 'PASSWORD')
-print('Welcome to  =>' , ftp.getwelcome())
+ftp.connect(config('Host', default='PUB400.COM'), 21, -999)
+ftp.login(config('user'), config('password'))
+print('Welcome to  =>', ftp.getwelcome())
 ftp.close()

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ This repository contains scripts and examples for transferring payroll data from
   password=PASSWORD
   ```
 
+### Using the public PUB400 IBM i server
+If you do not have access to an IBM i, you can create a free account at
+[pub400.com](https://pub400.com). After registering, copy `.env.example` to
+`.env` and update the `user` and `password` values with your PUB400
+credentials. The `Host` value should remain `PUB400.COM`.
+
 ## Usage
 1. Place `Data_EO.xls` in the project directory. The script will generate `Data_EO.csv`.
 2. Run the GUI:


### PR DESCRIPTION
## Summary
- Document using the free PUB400 IBM i server and provide sample environment file.
- Update FTP example script to read connection settings from `.env` with a default PUB400 host.

## Testing
- `python -m py_compile payroll_b.py Python_Scripts/Ftp_IBM_System_i.py`


------
https://chatgpt.com/codex/tasks/task_e_6897df30336083239207245bbef97b39

## Summary by Sourcery

Add support for configuring the FTP script via environment variables with defaults for the free PUB400 IBM i server and update documentation accordingly.

New Features:
- Include a .env.example file with placeholders for Host, user, and password

Enhancements:
- Load FTP host, user, and password from a .env file using python-decouple with a default host of PUB400.COM

Documentation:
- Document how to register for the free PUB400 IBM i server, set up .env from .env.example, and configure the script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an example environment configuration file to help users set up IBM i system connections.
* **Documentation**
  * Updated the README with instructions for connecting to the public PUB400 IBM i server, including environment setup guidance.
* **Chores**
  * Updated the script to use environment variables for IBM i connection details, improving flexibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->