### PR TITLE
Handle FTP connection errors and ensure cleanup

### DIFF
--- a/Python_Scripts/Ftp_IBM_System_i.py
+++ b/Python_Scripts/Ftp_IBM_System_i.py
@@ -4,21 +4,26 @@
 #                                                                                               
 #*************************************************************************************
 #  -*- coding: utf-8 -*-
-from ftplib import FTP, error_perm
+from ftplib import FTP, error_perm, all_errors
 from decouple import config, UndefinedValueError
+
+FTP_TIMEOUT = None
 
 ftp = FTP()
 try:
     user = config('user')
     password = config('password')
+    try:
+        ftp.connect(config('Host', default='PUB400.COM'), 21, timeout=FTP_TIMEOUT)
+    except (OSError, all_errors) as exc:
+        print('FTP connection failed:', exc)
+    else:
+        try:
+            ftp.login(user, password)
+            print('Welcome to  =>', ftp.getwelcome())
+        except error_perm as exc:
+            print('FTP login failed:', exc)
 except UndefinedValueError as exc:
     print('Missing credentials:', exc)
-else:
-    ftp.connect(config('Host', default='PUB400.COM'), 21, -999)
-    try:
-        ftp.login(user, password)
-        print('Welcome to  =>', ftp.getwelcome())
-    except error_perm as exc:
-        print('FTP login failed:', exc)
-    finally:
-        ftp.close()
+finally:
+    ftp.close()

--- a/payroll_b.py
+++ b/payroll_b.py
@@ -8,11 +8,13 @@
 import csv
 import sys
 import subprocess
-from ftplib import FTP
+from ftplib import FTP, all_errors
 import xlrd
 from decouple import config
 import time
 from colorama import init, Fore
+
+FTP_TIMEOUT = None
 
 # start colorama
 init()
@@ -48,12 +50,16 @@ def ftp_upload():
     file_transfer_name = "./Data_EO.csv"
     print('')
 
-    # Open ftp connection to the AS/400 server to start csv file transfer.
+    ftp = FTP()
     try:
         print(Fore.YELLOW + 'Establishing connection with IBM i Server (AS/400), please wait...')
-
-        ftp = FTP()
-        ftp.connect(config('Host'), 21, -999)
+        try:
+            ftp.connect(config('Host'), 21, timeout=FTP_TIMEOUT)
+        except (OSError, all_errors) as err:
+            print(Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err))
+            waiting_time = 13
+            time.sleep(waiting_time)
+            return
         ftp.login(config('user'), config('password'))
         print(Fore.GREEN + 'Connection established with ==>', ftp.getwelcome())
 
@@ -66,9 +72,8 @@ def ftp_upload():
             print(ftpResponse, file_transfer_name)
 
         ftp.quit()
-        ftp.close()
 
-        """ Call the interface to connect to IBM i - AS/400 via ftp and invoke the update and report 
+        """ Call the interface to connect to IBM i - AS/400 via ftp and invoke the update and report
         issuing programs... """
         completed_process = subprocess.run('ftp_cl_as400.bat')
         print(completed_process)
@@ -81,6 +86,8 @@ def ftp_upload():
         print(Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err))
         waiting_time = 13
         time.sleep(waiting_time)
+    finally:
+        ftp.close()
 
 
 if __name__ != "__main__":


### PR DESCRIPTION
## Summary
- guard FTP connections with explicit try/except to handle network failures
- ensure ftp.close runs in top-level finally blocks
- replace magic -999 timeout with named constant defaulting to None

## Testing
- `python -m py_compile Python_Scripts/Ftp_IBM_System_i.py payroll_b.py src/payroll_b.py`


------
https://chatgpt.com/codex/tasks/task_e_6897e778baf883238a301196d33c0859

## Summary by Sourcery

Guard FTP connections with try/except, replace magic timeout with a named constant, and ensure connections are closed in finally blocks

Bug Fixes:
- Ensure ftp.close() is always called in a top-level finally block to prevent resource leaks

Enhancements:
- Introduce FTP_TIMEOUT constant to replace hardcoded timeout values
- Import and catch ftplib.all_errors and wrap ftp.connect/login calls in nested exception handlers to report network or authentication failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for FTP connections and logins, with clearer messages and more reliable cleanup.
  * Ensured FTP connections are always properly closed, even if errors occur.
  * Added a configurable timeout for FTP connections.

* **Chores**
  * Updated import statements for better exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->