### PR TITLE
Refactor FTP error handling and cleanup

### DIFF
--- a/Python_Scripts/Ftp_IBM_System_i.py
+++ b/Python_Scripts/Ftp_IBM_System_i.py
@@ -15,7 +15,7 @@ try:
     password = config('password')
     try:
         ftp.connect(config('Host', default='PUB400.COM'), 21, timeout=FTP_TIMEOUT)
-    except (OSError, all_errors) as exc:
+    except all_errors as exc:
         print('FTP connection failed:', exc)
     else:
         try:

--- a/payroll_b.py
+++ b/payroll_b.py
@@ -11,7 +11,6 @@ import subprocess
 from ftplib import FTP, all_errors
 import xlrd
 from decouple import config
-import time
 from colorama import init, Fore
 
 FTP_TIMEOUT = None
@@ -26,9 +25,10 @@ def csv_from_excel():
         wb = xlrd.open_workbook('Data_EO.xls')
         sh = wb.sheet_by_index(0)
     except FileNotFoundError:
-        print(Fore.RED + "Opening the Data_EO.xls file failed, Please make sure that the file exists in the folder.")
-        waiting_time = 13
-        time.sleep(waiting_time)
+        print(
+            Fore.RED
+            + "Opening the Data_EO.xls file failed, Please make sure that the file exists in the folder."
+        )
         sys.exit(1)
 
     """ In order to avoid that the numeric fields of the csv file take an invalid value and as a consequence
@@ -55,10 +55,13 @@ def ftp_upload():
         print(Fore.YELLOW + 'Establishing connection with IBM i Server (AS/400), please wait...')
         try:
             ftp.connect(config('Host'), 21, timeout=FTP_TIMEOUT)
-        except (OSError, all_errors) as err:
-            print(Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err))
-            waiting_time = 13
-            time.sleep(waiting_time)
+        except all_errors as err:
+            print(
+                Fore.RED
+                + 'Could not establish connection to the server ===>:',
+                config('Host'),
+                str(err),
+            )
             return
         ftp.login(config('user'), config('password'))
         print(Fore.GREEN + 'Connection established with ==>', ftp.getwelcome())
@@ -83,11 +86,14 @@ def ftp_upload():
         print(completed_process)
 
     except Exception as err:
-        print(Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err))
-        waiting_time = 13
-        time.sleep(waiting_time)
+        print(
+            Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err)
+        )
     finally:
-        ftp.close()
+        try:
+            ftp.close()
+        except Exception as exc:
+            print('Error closing FTP connection:', exc)
 
 
 if __name__ != "__main__":

--- a/src/payroll_b.py
+++ b/src/payroll_b.py
@@ -11,7 +11,6 @@ import subprocess
 from ftplib import FTP, all_errors
 import xlrd
 from decouple import config
-import time
 from colorama import init, Fore
 
 # start colorama
@@ -27,9 +26,10 @@ def csv_from_excel():
         wb = xlrd.open_workbook('Data_EO.xls')
         sh = wb.sheet_by_index(0)
     except FileNotFoundError:
-        print(Fore.RED + "Opening the Data_EO.xls file failed, Please make sure that the file exists in the folder.")
-        waiting_time = 13
-        time.sleep(waiting_time)
+        print(
+            Fore.RED
+            + "Opening the Data_EO.xls file failed, Please make sure that the file exists in the folder."
+        )
         sys.exit(1)
 
     """ In order to avoid that the numeric fields of the csv file take an invalid value and as a consequence
@@ -56,12 +56,15 @@ def ftp_upload():
         print(Fore.YELLOW + 'Establishing connection with IBM i Server (AS/400), please wait...')
         try:
             ftp.connect(config('Host'), 21, timeout=FTP_TIMEOUT)
-        except (OSError, all_errors) as err:
-            print(Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err))
-            waiting_time = 13
-            time.sleep(waiting_time)
+        except all_errors as err:
+            print(
+                Fore.RED
+                + 'Could not establish connection to the server ===>:',
+                config('Host'),
+                str(err),
+            )
             return
-        ftp.login(config('User'), config('password'))
+        ftp.login(config('user'), config('password'))
         print(Fore.GREEN + 'Connection established with ==>', ftp.getwelcome())
 
         print(ftp.cwd("/tmp"))
@@ -84,11 +87,14 @@ def ftp_upload():
         print(completed_process)
 
     except Exception as err:
-        print(Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err))
-        waiting_time = 13
-        time.sleep(waiting_time)
+        print(
+            Fore.RED + 'Could not establish connection to the server ===>:', config('Host'), str(err)
+        )
     finally:
-        ftp.close()
+        try:
+            ftp.close()
+        except Exception as exc:
+            print('Error closing FTP connection:', exc)
 
 
 if __name__ != "__main__":


### PR DESCRIPTION
## Summary
- streamline FTP error handling by relying on `all_errors`
- handle FTP connection closure errors
- remove arbitrary delays and correct configuration key casing

## Testing
- `python -m py_compile Python_Scripts/Ftp_IBM_System_i.py payroll_b.py src/payroll_b.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897e9c42c10832396500a5a5fc6a6e0

## Summary by Sourcery

Refactor FTP error handling and cleanup by relying on all_errors, removing unnecessary delays, handling connection closure errors, and standardizing config key casing

Bug Fixes:
- Handle exceptions during FTP connection closure

Enhancements:
- Streamline FTP error handling by catching only all_errors
- Remove arbitrary time.sleep delays after errors
- Correct FTP login configuration key from 'User' to 'user'

Chores:
- Remove unused time import and simplify error print formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FTP connection error handling to provide clearer error messages and prevent unnecessary program delays.
  * Enhanced reliability when closing FTP connections by safely handling potential errors during closure.
  * Corrected configuration key usage for FTP login to prevent authentication issues.

* **Chores**
  * Removed unnecessary delays and unused imports for more efficient program execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->