### PR TITLE
Use sys.executable for subprocess and update docs

### DIFF
--- a/payroll_utils.py
+++ b/payroll_utils.py
@@ -8,6 +8,7 @@ import csv
 import logging
 import os
 import subprocess
+import sys
 from ftplib import FTP, all_errors
 
 import xlrd
@@ -29,9 +30,11 @@ def csv_from_excel(
     Parameters
     ----------
     xls_file: str, optional
-        Source Excel file name. Defaults to ``Data_EO.xls``.
+        Source Excel file name. Defaults to the ``XLS_FILE`` environment
+        variable or ``Data_EO.xls`` if not set.
     csv_file: str, optional
-        Destination CSV file name. Defaults to ``Data_EO.csv``.
+        Destination CSV file name. Defaults to the ``CSV_FILE`` environment
+        variable or ``Data_EO.csv`` if not set.
     """
 
     xls_file = xls_file or config("XLS_FILE", default="Data_EO.xls")
@@ -71,7 +74,21 @@ def csv_from_excel(
 
 
 def ftp_upload(file_transfer_name: Optional[str] = None) -> None:
-    """Upload the generated CSV to the IBM i server and run post-processing."""
+    """Upload the generated CSV to the IBM i server and run post-processing.
+
+    Parameters
+    ----------
+    file_transfer_name: str, optional
+        Path of the CSV to transfer. Defaults to the ``CSV_FILE`` environment
+        variable or ``Data_EO.csv`` if not set.
+
+    Raises
+    ------
+    ftplib.all_errors
+        If any FTP error occurs.
+    subprocess.CalledProcessError
+        If any of the invoked subprocesses fail.
+    """
 
     ftp = FTP()
     logger.info("")
@@ -100,7 +117,7 @@ def ftp_upload(file_transfer_name: Optional[str] = None) -> None:
         subprocess.run(["ftp_cl_as400.bat"], check=True)
 
         # Successfully completed process
-        subprocess.run(["python", "payroll_process_done.py"], check=True)
+        subprocess.run([sys.executable, "payroll_process_done.py"], check=True)
 
     except all_errors as err:
         logger.error(

--- a/src/payroll.py
+++ b/src/payroll.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
 import subprocess
 import time
 from tkinter import Tk, RIGHT, LEFT, HORIZONTAL, StringVar
@@ -27,10 +28,13 @@ def button_confirm():
         payroll_b_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), '../payroll_b.py')
         )
-        completed_process = subprocess.run(['python', payroll_b_path])
+        completed_process = subprocess.run(
+            [sys.executable, payroll_b_path], check=True
+        )
         print(completed_process)
-    except:
-        print("An error has occurred in payroll_b")
+    except subprocess.CalledProcessError as exc:
+        print(f"An error has occurred in payroll_b: {exc}")
+        raise
     else:
         print("Successful execution of payroll_b")
 


### PR DESCRIPTION
## Summary
- run payroll_b with an absolute path and the current interpreter
- document environment variable defaults for csv_from_excel and ftp_upload
- clarify FTP upload error handling and use sys.executable for post-processing

## Testing
- `python -m py_compile src/payroll.py payroll_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6897f11bc7048323b59a8ec84a2d27df

## Summary by Sourcery

Use the current Python interpreter for all subprocess calls, tighten error handling, and enhance documentation for environment variable defaults and FTP upload behavior.

Bug Fixes:
- Replace broad except clauses with subprocess.CalledProcessError handling and rethrow errors in payroll invocation.

Enhancements:
- Use sys.executable and check=True for subprocess.run calls to ensure consistent interpreter usage and fail-fast behavior.

Documentation:
- Document XLS_FILE and CSV_FILE environment variable defaults in csv_from_excel docstring.
- Clarify ftp_upload parameters, error conditions, and raised exceptions in its docstring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of subprocess execution by ensuring the current Python interpreter is used and errors are more clearly reported.
* **Documentation**
  * Enhanced parameter and exception documentation for file processing and FTP upload functions.
* **Chores**
  * Updated logic to use environment variables for file naming, providing clearer default behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->