### PR TITLE
Mitigate subprocess command injection risks

### DIFF
--- a/payroll_utils.py
+++ b/payroll_utils.py
@@ -114,10 +114,13 @@ def ftp_upload(file_transfer_name: Optional[str] = None) -> None:
         ftp.quit()
 
         # Call the interface to connect to IBM i via FTP and invoke update programs
-        subprocess.run(["ftp_cl_as400.bat"], check=True)
+        subprocess.run(["ftp_cl_as400.bat"], check=True, shell=False)
 
         # Successfully completed process
-        subprocess.run([sys.executable, "payroll_process_done.py"], check=True)
+        done_script = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "payroll_process_done.py")
+        )
+        subprocess.run([sys.executable, done_script], check=True, shell=False)
 
     except all_errors as err:
         logger.error(

--- a/src/payroll.py
+++ b/src/payroll.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import os
 import sys
 import subprocess
 import time
+from pathlib import Path
 from tkinter import Tk, RIGHT, LEFT, HORIZONTAL, StringVar
 from tkinter.ttk import *
 
@@ -25,11 +25,9 @@ def button_confirm():
                 str(int((x / task) * 100)) + "% Iniciando Interfaz. Por Favor, Espere Hasta Que El Proceso Termine.")
             WindowFrame.update_idletasks()
 
-        payroll_b_path = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), '../payroll_b.py')
-        )
+        payroll_b_path = Path(__file__).resolve().parent.parent / "payroll_b.py"
         completed_process = subprocess.run(
-            [sys.executable, payroll_b_path], check=True
+            [sys.executable, str(payroll_b_path)], check=True, shell=False
         )
         print(completed_process)
     except subprocess.CalledProcessError as exc:


### PR DESCRIPTION
## Summary
- Safeguard subprocess invocation in payroll utilities by resolving script paths and disabling shell usage
- Harden payroll GUI by running payroll_b via an absolute path with shell disabled

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897f39cebd48323b58ac31e7afbc238