### PR TITLE
Use Pathlib and validate scripts before subprocess

### DIFF
--- a/src/payroll.py
+++ b/src/payroll.py
@@ -25,7 +25,9 @@ def button_confirm():
                 str(int((x / task) * 100)) + "% Iniciando Interfaz. Por Favor, Espere Hasta Que El Proceso Termine.")
             WindowFrame.update_idletasks()
 
-        payroll_b_path = Path(__file__).resolve().parent.parent / "payroll_b.py"
+        payroll_b_path = (Path(__file__).resolve().parent.parent / "payroll_b.py").resolve()
+        if not payroll_b_path.is_file():
+            raise FileNotFoundError(f"Missing payroll_b script: {payroll_b_path}")
         completed_process = subprocess.run(
             [sys.executable, str(payroll_b_path)], check=True, shell=False
         )


### PR DESCRIPTION
## Summary
- Consistently use `Path` in FTP upload utilities and verify batch/completion scripts exist before running them.
- Ensure batch file runs via `cmd` on Windows and fail fast if expected scripts are missing.
- Guard GUI entrypoint by checking for `payroll_b.py` before invoking it.

## Testing
- `python -m py_compile payroll_utils.py src/payroll.py`


------
https://chatgpt.com/codex/tasks/task_e_6897fa9dd248832396c511c815cbbf60

## Summary by Sourcery

Switch path handling to pathlib, add pre-execution checks for required scripts (FTP batch, completion script, payroll_b), and ensure batch files run via cmd on Windows.

Enhancements:
- Adopt pathlib.Path for all file path manipulations in ftp utilities and payroll entrypoint
- Validate existence of external scripts (batch files and Python scripts) before invoking them
- Log an error and raise FileNotFoundError for missing scripts to fail fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing batch and Python scripts during payroll file uploads, with clear error messages if files are not found.
* **Documentation**
  * Updated documentation to reflect new error handling behavior for missing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->