### PR TITLE
Harden subprocess usage

### DIFF
--- a/ibmi_transfer.py
+++ b/ibmi_transfer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import ftplib
 import os
 import subprocess
+import shlex
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -98,10 +99,6 @@ def call_program_via_ssh(
     if key_path:
         ssh_cmd.extend(["-i", key_path])
     ssh_cmd.append(f"{user}@{host}")
-    ssh_cmd.append(cmd)
-    proc = subprocess.run(ssh_cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-        raise subprocess.CalledProcessError(
-            proc.returncode, ssh_cmd, output=proc.stdout, stderr=proc.stderr
-        )
-    return proc
+    # Split the remote command into tokens to avoid shell injection issues
+    ssh_cmd.extend(shlex.split(cmd))
+    return subprocess.run(ssh_cmd, capture_output=True, text=True, check=True)

--- a/payroll.py
+++ b/payroll.py
@@ -5,6 +5,7 @@ import time
 from PIL import Image, ImageTk
 import subprocess
 import sys
+from pathlib import Path
 
 
 def button_confirm():
@@ -23,7 +24,11 @@ def button_confirm():
                 str(int((x / task) * 100)) + "% Iniciando Interfaz. Por Favor, Espere Hasta Que El Proceso Termine.")
             WindowFrame.update_idletasks()
 
-        completed_process = subprocess.run([sys.executable, 'payroll_b.py'])
+        script_path = Path(__file__).with_name("payroll_b.py")
+        completed_process = subprocess.run([
+            sys.executable,
+            str(script_path),
+        ], check=True)
         print(completed_process)
 
     except Exception:

--- a/tests/test_ibmi_transfer.py
+++ b/tests/test_ibmi_transfer.py
@@ -79,10 +79,12 @@ def test_call_program_via_ftp_rcmd(monkeypatch):
 def test_call_program_via_ssh(monkeypatch):
     called = {}
 
-    def fake_run(cmd, capture_output, text):
+    def fake_run(cmd, capture_output, text, **kwargs):
         called["cmd"] = cmd
+        called.update(kwargs)
         return mock.Mock(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(ibmi_transfer.subprocess, "run", fake_run)
     ibmi_transfer.call_program_via_ssh("h", "u", "cmd", key_path="k")
     assert called["cmd"] == ["ssh", "-i", "k", "u@h", "cmd"]
+    assert called.get("check") is True


### PR DESCRIPTION
## Summary
- Prevent shell injection in SSH command helper by tokenizing user-supplied command and enabling `check=True`
- Run payroll helper script via explicit path and enforce `check=True` for subprocess
- Update tests for new subprocess invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689968b9c2c083239580a2a2715d06df

## Summary by Sourcery

Harden subprocess usage by splitting remote command arguments to avoid shell injection, enforcing check=True on subprocess.run calls, and resolving the payroll script path explicitly

Bug Fixes:
- Prevent shell injection in SSH helper by tokenizing the remote command arguments

Enhancements:
- Enforce check=True on subprocess.run in both SSH and payroll scripts to raise on failures
- Resolve payroll_b.py using an explicit pathlib.Path next to the main script

Tests:
- Update SSH helper test to assert check=True was passed to subprocess.run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Safer remote command execution with proper argument handling to reduce injection risk.
  - Errors from subprocess calls now surface immediately, preventing silent failures.
  - More reliable script launching by using absolute paths, avoiding path-related issues.

- Tests
  - Expanded tests to verify error propagation and subprocess invocation parameters.

- Chores
  - General robustness improvements around command execution and process handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->