### PR TITLE
chore: revamp CI workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude =
+    build,
+    dist,
+    .venv,
+    venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,62 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OS packages
+        run: sudo apt-get update && sudo apt-get install -y python3-tk openssh-client
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: setup
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - run: pip install -r requirements.txt
-      - run: pip install pytest flake8 ruff
-      - run: ruff check . --exclude src
-      - run: flake8 . --exclude src
-      - run: pytest
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt flake8
+      - name: Ruff
+        run: ruff check .
+      - name: Flake8
+        run: flake8 .
+
+  tests:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OS packages
+        run: sudo apt-get update && sudo apt-get install -y python3-tk openssh-client
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest
+      - name: Run tests
+        env:
+          HOST: localhost
+          USER: test
+          PASSWORD: test
+          REMOTE_DIR: /tmp
+          LIB: QGPL
+          PROGRAM: PGM
+          USE_SSH: '1'
+        run: pytest

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,13 @@
+line-length = 88
+target-version = "py311"
+
+exclude = [
+  "build",
+  "dist",
+  ".venv",
+  "venv",
+]
+
+[lint]
+select = ["E", "F", "B", "I"]
+ignore = ["E501"]


### PR DESCRIPTION
## Summary
- split CI into setup, lint and tests jobs
- install required OS packages and pin Python 3.11
- add Ruff and Flake8 configuration files

## Testing
- `ruff check .` (fails: import/order issues)
- `flake8 .` (fails: command not found)
- `HOST=localhost USER=dummy PASSWORD=dummy REMOTE_DIR=/tmp LIB=QGPL PROGRAM=PGM USE_SSH=0 pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc2a2846c832389ede4cf59f56f64