### PR TITLE
Harden IBM i file transfer security

### DIFF
--- a/Python_Scripts/Sftp_IBM_System_i.py
+++ b/Python_Scripts/Sftp_IBM_System_i.py
@@ -17,16 +17,16 @@ def main() -> None:
         raise RuntimeError("Missing USER or PASSWORD environment variables")
 
     client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.load_system_host_keys()
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())
+    sftp = None
     try:
         client.connect(host, username=user, password=password)
         sftp = client.open_sftp()
         print("SFTP connection established to", host)
     finally:
-        try:
+        if sftp is not None:
             sftp.close()
-        except Exception:
-            pass
         client.close()
 
 

--- a/ibmi/apply.sql
+++ b/ibmi/apply.sql
@@ -1,5 +1,5 @@
--- Validate, transform and merge into shadow tables. Uses ${LIB_STG} variable.
-SET SCHEMA ${LIB_STG};
+-- Validate, transform and merge into shadow tables. Replace LIB_STG_PLACEHOLDER with the target schema.
+SET SCHEMA LIB_STG_PLACEHOLDER;
 
 -- Reset staging tables
 DELETE FROM RAC_STG_VALID;

--- a/ibmi/setup.sql
+++ b/ibmi/setup.sql
@@ -1,7 +1,7 @@
--- Setup staging schema and tables. Uses ${LIB_STG} variable.
-CREATE SCHEMA IF NOT EXISTS ${LIB_STG};
+-- Setup staging schema and tables. Replace LIB_STG_PLACEHOLDER with the target schema.
+CREATE SCHEMA IF NOT EXISTS LIB_STG_PLACEHOLDER;
 
-SET SCHEMA ${LIB_STG};
+SET SCHEMA LIB_STG_PLACEHOLDER;
 
 CREATE TABLE IF NOT EXISTS RAC_STG_IN (
     RAW_LINE VARCHAR(512)

--- a/ibmi/teardown.sql
+++ b/ibmi/teardown.sql
@@ -1,2 +1,2 @@
--- Drop staging schema. Uses ${LIB_STG} variable.
-DROP SCHEMA ${LIB_STG} CASCADE;
+-- Drop staging schema. Replace LIB_STG_PLACEHOLDER with the target schema.
+DROP SCHEMA LIB_STG_PLACEHOLDER CASCADE;

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -63,7 +63,7 @@ def run_workflow(
             for script in ("setup.sql", "apply.sql", "process.clp", "teardown.sql"):
                 local_script = Path("ibmi") / script
                 text = local_script.read_text()
-                text = text.replace("${LIB_STG}", lib_stg)
+                text = text.replace("LIB_STG_PLACEHOLDER", lib_stg)
                 with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
                     tmp.write(text)
                     tmp_path = Path(tmp.name)

--- a/tests/test_ibmi_transfer.py
+++ b/tests/test_ibmi_transfer.py
@@ -28,6 +28,9 @@ def test_upload_csv_via_sftp(monkeypatch, tmp_path):
         def set_missing_host_key_policy(self, policy):
             pass
 
+        def load_system_host_keys(self):
+            pass
+
         def connect(self, host, username, password):
             self.host = host
             self.username = username
@@ -40,12 +43,12 @@ def test_upload_csv_via_sftp(monkeypatch, tmp_path):
         def close(self):
             pass
 
-    monkeypatch.setattr(ibmi_transfer, "paramiko", SimpleNamespace(SSHClient=FakeSSHClient, AutoAddPolicy=object))
+    monkeypatch.setattr(ibmi_transfer, "paramiko", SimpleNamespace(SSHClient=FakeSSHClient, RejectPolicy=object))
     local = tmp_path / "sample.csv"
     local.write_text("hello")
     ibmi_transfer.upload_csv_via_sftp("h", "u", "p", local, "/tmp")
     client = FakeSSHClient.last
-    assert client.sftp.put_calls == [(str(local), f"/tmp/{local.name}")]
+    assert client.sftp.put_calls == [(str(local), f"/tmp/{local.name}")]  # nosec
 
 
 def test_call_program_via_ssh(monkeypatch):
@@ -58,5 +61,5 @@ def test_call_program_via_ssh(monkeypatch):
 
     monkeypatch.setattr(ibmi_transfer.subprocess, "run", fake_run)
     ibmi_transfer.call_program_via_ssh("h", "u", "cmd", key_path="k")
-    assert called["cmd"] == ["ssh", "-i", "k", "u@h", "cmd"]
-    assert called.get("check") is True
+    assert called["cmd"] == ["ssh", "-i", "k", "u@h", "cmd"]  # nosec
+    assert called.get("check") is True  # nosec

--- a/tests/test_xls_to_csv.py
+++ b/tests/test_xls_to_csv.py
@@ -17,5 +17,5 @@ def test_xls_to_csv(tmp_path):
     csv_from_excel(str(xls), str(out))
     with out.open() as fh:
         rows = list(csv.reader(fh))
-    assert rows[0][0].strip() == "1001"
-    assert rows[0][1] == "1234.56"
+    assert rows[0][0].strip() == "1001"  # nosec
+    assert rows[0][1] == "1234.56"  # nosec


### PR DESCRIPTION
## Summary
- enforce host key verification in SFTP/SSH helpers
- validate SSH command inputs and reject unsafe separators
- convert SQL templates to explicit placeholders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a747b351088323b26d881c9355c9d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Stronger SSH/SFTP security: stricter host key verification, rejection of unknown hosts, and validation of host/user/paths; unsafe command separators are blocked.
  - More robust SFTP cleanup when connections fail.
  - Workflow SQL templates now use LIB_STG_PLACEHOLDER; replace with your target schema before running.
  - SSH program runner now accepts commands as a string or a list.

- Tests
  - Updated test stubs and patches to match new host key policies and APIs; added security annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->