### PR TITLE
Add Codacy coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+name: coverage
+on:
+  pull_request:
+  push:
+    branches: ["**"]
+
+jobs:
+  python-coverage:
+    name: Python coverage → Codacy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+          pip install pytest pytest-cov coverage
+
+      - name: Run tests & build Cobertura report
+        run: pytest --maxfail=1 --disable-warnings --cov=. --cov-report=xml:coverage.xml
+
+      - name: Upload coverage to Codacy
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IBM i Payroll Upload Tool
 
+[![Codacy coverage](https://app.codacy.com/project/badge/Coverage/PROJECT_ID)](https://app.codacy.com/gh/TylrDn/IBM-System-i_AS400/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
+
 Convert an Excel payroll extract to CSV, upload it to the IBM i (formerly AS/400) Integrated File System (IFS), and invoke a program to apply salary adjustments. The tool uses SSH/SFTP by default but also supports FTPS.
 
 **Flow:** XLS → CSV → IFS upload → `CALL LIB/PROGRAM (PARMS)`
@@ -66,6 +68,10 @@ A sample file is provided in [`examples/payroll_sample.csv`](examples/payroll_sa
 - Sample data lives in [`examples/`](examples/).
 - See [CONTRIBUTING](CONTRIBUTING.md) for development guidelines.
 - Licensed under the [MIT License](LICENSE).
+
+## Test coverage via Codacy
+
+Coverage reports from `pytest --cov` are uploaded to [Codacy](https://www.codacy.com/) on every push and pull request.
 
 
 ## PUB400 Quick Start


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests with coverage and upload to Codacy
- document Codacy coverage badge and reporting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76562b45c8323a1d0ccfa07ae4544