### PR TITLE
Enable Codacy coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+source = .
+omit =
+    tests/*
+
+[report]
+show_missing = true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,8 @@ jobs:
   python-coverage:
     name: Python coverage → Codacy
     runs-on: ubuntu-latest
+    env:
+      CODACY_PROJECT_TOKEN: 267af9c0d6a74aa6b0f05c0d60b48264
 
     steps:
       - name: Checkout
@@ -21,13 +23,11 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt || true
+          pip install -r requirements.txt
           pip install pytest pytest-cov coverage
 
       - name: Run tests & build Cobertura report
         run: pytest --maxfail=1 --disable-warnings --cov=. --cov-report=xml:coverage.xml
 
       - name: Upload coverage to Codacy
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ VENV?=.venv
 PYTHON=$(VENV)/bin/python
 PIP=$(VENV)/bin/pip
 
-.PHONY: dev legacy-run test lint package install run sync setup clean-staging
+.PHONY: dev legacy-run test lint package install run sync setup clean-staging coverage
 
 dev:
 	python3 -m venv $(VENV)
 	$(PIP) install -r requirements.txt
-	$(PIP) install pytest flake8 ruff pyinstaller
+	$(PIP) install pytest flake8 ruff pyinstaller pytest-cov coverage
 
 legacy-run: dev
 	$(PYTHON) payroll.py
@@ -36,3 +36,7 @@ lint: dev
 
 package: dev
 	$(VENV)/bin/pyinstaller pyinstaller.spec
+
+coverage: dev
+	$(PYTHON) -m pytest --cov=. --cov-report=xml:coverage.xml
+	bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ A sample file is provided in [`examples/payroll_sample.csv`](examples/payroll_sa
 
 Coverage reports from `pytest --cov` are uploaded to [Codacy](https://www.codacy.com/) on every push and pull request.
 
+To run this locally and upload results, set your project token and invoke the `coverage` target:
+
+```bash
+export CODACY_PROJECT_TOKEN=267af9c0d6a74aa6b0f05c0d60b48264
+make coverage
+```
+
 
 ## PUB400 Quick Start
 This project can connect to any IBM i, including PUB400, via SFTP/SSH or FTPS. Configure the application using variables defined in `.env`.


### PR DESCRIPTION
## Summary
- add coverage configuration and Makefile target for Codacy uploads
- embed repository token in coverage workflow and tighten dependency installs
- document how to run and upload coverage locally

## Testing
- `pytest`
- `make coverage` *(fails: Could not find a version that satisfies the requirement Pillow>=10.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a76642b2f08323a760b01e89daea53