### PR TITLE
Add comprehensive tests for utilities and workflow

### DIFF
--- a/tests/test_payroll_gui.py
+++ b/tests/test_payroll_gui.py
@@ -1,0 +1,88 @@
+import sys
+import types
+import pytest
+
+
+def import_gui(monkeypatch, module_name):
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def config(self, *a, **k):
+             pass
+
+        def configure(self, *a, **k):
+             pass
+
+    class DummyWindow(DummyWidget):
+        def __init__(self):
+            self.tk = object()
+
+        def geometry(self, *a):
+            pass
+
+        def title(self, *a):
+            pass
+
+        def update_idletasks(self):
+            pass
+
+        def quit(self):
+            pass
+
+        def resizable(self, *a):
+            pass
+
+        def mainloop(self):
+            pass
+
+    monkeypatch.setattr(sys, "argv", [module_name])
+    monkeypatch.setattr("tkinter.Tk", lambda: DummyWindow())
+    monkeypatch.setattr("tkinter.Label", DummyWidget)
+    monkeypatch.setattr("tkinter.Button", DummyWidget)
+    monkeypatch.setattr("tkinter.ttk.Label", DummyWidget)
+    monkeypatch.setattr("tkinter.ttk.Button", DummyWidget)
+    monkeypatch.setattr("tkinter.ttk.Progressbar", DummyWidget)
+    monkeypatch.setattr("tkinter.StringVar", lambda: types.SimpleNamespace(set=lambda *a, **k: None))
+    monkeypatch.setattr("PIL.Image.open", lambda *a, **k: object())
+    monkeypatch.setattr("PIL.ImageTk.PhotoImage", lambda *a, **k: object())
+    __import__(module_name)
+    return sys.modules[module_name]
+
+
+@pytest.mark.parametrize("module_name,win_attr", [("payroll", "window"), ("src.payroll", "WindowFrame")])
+def test_button_confirm_success(monkeypatch, module_name, win_attr):
+    mod = import_gui(monkeypatch, module_name)
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(mod.Path, "is_file", lambda self: True)
+    setattr(mod, win_attr, types.SimpleNamespace(update_idletasks=lambda: None, quit=lambda: None))
+    mod.progress_bar = {"value": 0}
+    mod.percent = types.SimpleNamespace(set=lambda *a, **k: None)
+    mod.payroll_b = types.SimpleNamespace(main=lambda: 0)
+    mod.button_confirm()
+    assert mod.progress_bar["value"] == 100
+
+
+@pytest.mark.parametrize("module_name,win_attr", [("payroll", "window"), ("src.payroll", "WindowFrame")])
+def test_button_confirm_error(monkeypatch, module_name, win_attr):
+    mod = import_gui(monkeypatch, module_name)
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(mod.Path, "is_file", lambda self: True)
+    setattr(mod, win_attr, types.SimpleNamespace(update_idletasks=lambda: None, quit=lambda: None))
+    mod.progress_bar = {"value": 0}
+    mod.percent = types.SimpleNamespace(set=lambda *a, **k: None)
+    mod.payroll_b = types.SimpleNamespace(main=lambda: 1)
+    with pytest.raises(RuntimeError):
+        mod.button_confirm()
+
+
+@pytest.mark.parametrize("module_name,win_attr", [("payroll", "window"), ("src.payroll", "WindowFrame")])
+def test_button_cancel(monkeypatch, module_name, win_attr):
+    mod = import_gui(monkeypatch, module_name)
+    called = {}
+    setattr(mod, win_attr, types.SimpleNamespace(quit=lambda: called.setdefault("q", True)))
+    mod.button_cancel()
+    assert called.get("q")

--- a/tests/test_payroll_utils.py
+++ b/tests/test_payroll_utils.py
@@ -1,0 +1,91 @@
+import logging
+import sys
+from pathlib import Path
+import types
+import pytest
+import builtins
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import payroll_utils  # noqa: E402
+
+
+def test_open_sheet_success(monkeypatch):
+    class FakeBook:
+        def sheet_by_index(self, idx):
+            return "sheet"
+
+    monkeypatch.setattr(payroll_utils.xlrd, "open_workbook", lambda f: FakeBook())
+    sheet = payroll_utils._open_sheet("file.xls")
+    assert sheet == "sheet"
+
+
+def test_open_sheet_file_missing(monkeypatch, caplog):
+    def fake_open(path):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(payroll_utils.xlrd, "open_workbook", fake_open)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(FileNotFoundError):
+            payroll_utils._open_sheet("bad.xls")
+        assert "Opening the bad.xls file failed" in caplog.text
+
+
+def test_open_sheet_xlrd_error(monkeypatch, caplog):
+    def fake_open(path):
+        raise payroll_utils.xlrd.biffh.XLRDError("boom")
+
+    monkeypatch.setattr(payroll_utils.xlrd, "open_workbook", fake_open)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(payroll_utils.xlrd.biffh.XLRDError):
+            payroll_utils._open_sheet("bad.xls")
+        assert "Failed to open bad.xls" in caplog.text
+
+
+def test_write_sheet_to_csv_success(tmp_path):
+    class Sheet:
+        nrows = 2
+
+        def row_values(self, row):
+            return [row, row + 1]
+
+    csv_file = tmp_path / "out.csv"
+    count = payroll_utils._write_sheet_to_csv(Sheet(), csv_file.as_posix())
+    assert count == 2
+    assert csv_file.read_text().strip().splitlines()[0] == "0,1"
+
+
+def test_write_sheet_to_csv_oserror(monkeypatch, tmp_path, caplog):
+    class Sheet:
+        nrows = 1
+
+        def row_values(self, row):
+            return [1]
+
+    def fake_open(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError):
+            payroll_utils._write_sheet_to_csv(Sheet(), (tmp_path / "out.csv").as_posix())
+        assert "Failed to write to CSV file" in caplog.text
+
+
+def test_csv_from_excel_success(monkeypatch):
+    monkeypatch.setattr(payroll_utils, "_open_sheet", lambda f: "sheet")
+    called = {}
+
+    def fake_write(sheet, csv_file):
+        called["args"] = (sheet, csv_file)
+        return 1
+
+    monkeypatch.setattr(payroll_utils, "_write_sheet_to_csv", fake_write)
+    payroll_utils.csv_from_excel("in.xls", "out.csv")
+    assert called["args"] == ("sheet", "out.csv")
+
+
+def test_csv_from_excel_missing_paths(monkeypatch):
+    monkeypatch.setattr(payroll_utils.os, "getenv", lambda *a, **k: None)
+    with pytest.raises(ValueError):
+        payroll_utils.csv_from_excel(None, None)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,95 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import src.runner as runner  # noqa: E402
+
+
+def test_parse_args(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["runner", "--file", "input.csv"])
+    args = runner.parse_args()
+    assert args.file == "input.csv"
+    assert not args.sync
+
+
+def test_main_runs_workflow(monkeypatch):
+    args = types.SimpleNamespace(
+        file="f.csv",
+        sync=True,
+        fetch_outputs=True,
+        dry_run=False,
+        timeout_seconds=1,
+        jobq=None,
+        outq=None,
+        lib_stg=None,
+        ifs_dir=None,
+        teardown=False,
+    )
+    monkeypatch.setattr(runner, "parse_args", lambda: args)
+    cfg = types.SimpleNamespace(jobq="J", outq="O", lib_stg="L", ifs_dir="/ifs")
+    monkeypatch.setattr(runner, "load_config", lambda: cfg)
+    called = {}
+
+    def fake_run_workflow(path, cfg_obj, **opts):
+        called["path"] = path
+        called.update(opts)
+
+    monkeypatch.setattr(runner, "run_workflow", fake_run_workflow)
+    assert runner.main() == 0
+    assert called["path"] == Path("f.csv")
+    assert called["sync"]
+
+
+def test_main_teardown(monkeypatch):
+    args = types.SimpleNamespace(
+        file="f.csv",
+        sync=False,
+        fetch_outputs=False,
+        dry_run=True,
+        timeout_seconds=5,
+        jobq=None,
+        outq=None,
+        lib_stg=None,
+        ifs_dir=None,
+        teardown=True,
+    )
+    monkeypatch.setattr(runner, "parse_args", lambda: args)
+    cfg = types.SimpleNamespace(jobq="J", outq="O", lib_stg="L", ifs_dir="/ifs")
+    monkeypatch.setattr(runner, "load_config", lambda: cfg)
+    called = {}
+
+    def fake_teardown(cfg_arg, dry_run):
+        called["cfg"] = cfg_arg
+        called["dry_run"] = dry_run
+
+    import src.workflow as wf
+
+    monkeypatch.setattr(wf, "teardown", fake_teardown)
+    assert runner.main() == 0
+    assert called["dry_run"]
+
+
+def test_main_error(monkeypatch):
+    args = types.SimpleNamespace(
+        file="f.csv",
+        sync=False,
+        fetch_outputs=False,
+        dry_run=False,
+        timeout_seconds=0,
+        jobq=None,
+        outq=None,
+        lib_stg=None,
+        ifs_dir=None,
+        teardown=False,
+    )
+    monkeypatch.setattr(runner, "parse_args", lambda: args)
+
+    def bad_config():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runner, "load_config", bad_config)
+    assert runner.main() == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,86 @@
+import hashlib
+import logging
+import sys
+from pathlib import Path
+import hashlib
+import logging
+import sys
+from pathlib import Path
+import types
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import src.utils as utils  # noqa: E402
+
+
+def test_setup_logger(caplog):
+    utils.setup_logger(logging.DEBUG)
+    with caplog.at_level(logging.DEBUG):
+        logging.getLogger(__name__).debug("msg")
+    assert "msg" in caplog.text
+
+
+def test_timed_decorator(monkeypatch, caplog):
+    import itertools
+
+    counter = itertools.count()
+    monkeypatch.setattr(utils.time, "time", lambda: next(counter))
+
+    @utils.timed
+    def sample(x):
+        return x * 2
+
+    with caplog.at_level(logging.DEBUG):
+        assert sample(3) == 6
+    assert "sample took" in caplog.text
+
+
+def test_sniff_csv_normalises(tmp_path):
+    p = tmp_path / "a.csv"
+    p.write_text("a,b\r\nc,d\re,f")
+    dialect = utils.sniff_csv(p)
+    assert dialect.delimiter == ","
+    assert p.read_text() == "a,b\nc,d\ne,f"
+
+
+def test_xlsx_to_csv(monkeypatch, tmp_path):
+    df = types.SimpleNamespace(to_csv=lambda path, index=False, line_terminator="\n": Path(path).write_text("x"))
+    monkeypatch.setattr(utils.pd, "read_excel", lambda path: df)
+    out = utils.xlsx_to_csv(Path("in.xlsx"), tmp_path / "out.csv")
+    assert out.read_text() == "x"
+
+
+def test_sha256_file_success(tmp_path):
+    f = tmp_path / "f.txt"
+    f.write_text("hello")
+    assert (
+        utils.sha256_file(f)
+        == hashlib.sha256(b"hello").hexdigest()
+    )
+
+
+def test_sha256_file_not_file(tmp_path):
+    with pytest.raises(ValueError):
+        utils.sha256_file(tmp_path)
+
+
+def test_load_config_success(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text(
+        "IBMI_HOST=h\nIBMI_USER=u\nLIB_STG=l\nIFS_STAGING_DIR=/ifs\n"
+    )
+    for key in ("IBMI_HOST", "IBMI_USER", "LIB_STG", "IFS_STAGING_DIR"):
+        monkeypatch.delenv(key, raising=False)
+    cfg = utils.load_config(str(env))
+    assert cfg.host == "h"
+    assert cfg.jobq == "QSYSNOMAX"
+
+
+def test_load_config_missing(tmp_path, monkeypatch):
+    env = tmp_path / ".env"
+    env.write_text("IBMI_HOST=h\n")
+    for key in ("IBMI_USER", "LIB_STG", "IFS_STAGING_DIR"):
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(ValueError):
+        utils.load_config(str(env))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,215 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import src.workflow as wf  # noqa: E402
+
+
+def test_ensure_safe():
+    assert wf._ensure_safe("abc_123", "f") == "abc_123"
+    with pytest.raises(ValueError):
+        wf._ensure_safe("bad;rm", "f")
+
+
+def test_remote_dirs():
+    assert wf._remote_dirs("/ifs")[-1] == "/ifs/scripts"
+
+
+def test_prepare_csv(monkeypatch, tmp_path):
+    src = tmp_path / "input.xlsx"
+    src.write_text("dummy")
+    csv_path = tmp_path / "input.csv"
+    called = {"xlsx": False, "sniff": False, "sha": False}
+    monkeypatch.setattr(wf, "xlsx_to_csv", lambda i, o: called.__setitem__("xlsx", True) or csv_path)
+    monkeypatch.setattr(wf, "sniff_csv", lambda p: called.__setitem__("sniff", True))
+    monkeypatch.setattr(wf, "sha256_file", lambda p: called.__setitem__("sha", True) or "digest")
+    out = wf._prepare_csv(src, logging.getLogger(__name__))
+    assert out == csv_path
+    assert all(called.values())
+
+
+def test_sync_scripts(tmp_path):
+    puts = []
+
+    class Client:
+        def sftp_put(self, local, remote):
+            puts.append((local, remote))
+
+    wf._sync_scripts(Client(), "/ifs")
+    assert (Path("ibmi") / "setup.sql", "/ifs/scripts/setup.sql") in puts
+
+
+def test_run_setup_and_submit_job():
+    cmds = []
+
+    class Client:
+        def ssh_run(self, cmd):
+            cmds.append(cmd)
+
+    wf._run_setup(Client(), "/ifs", "LIB")
+    wf._submit_job(Client(), "LIB", "/ifs", "OUTQ", "JOBQ")
+    assert any("RUNSQLSTM" in c for c in cmds)
+    assert any("SBMJOB" in c for c in cmds)
+
+
+def test_find_status_file(monkeypatch):
+    class Client:
+        def __init__(self):
+            self.calls = 0
+            self.sftp = types.SimpleNamespace(listdir=self.listdir)
+
+        def listdir(self, path):
+            self.calls += 1
+            return [] if self.calls < 2 else ["done.status"]
+
+    times = iter([0, 1, 2])
+    monkeypatch.setattr(wf.time, "time", lambda: next(times))
+    status = wf._find_status_file(Client(), "dir", 5)
+    assert status == "done.status"
+
+
+def test_find_status_file_timeout(monkeypatch):
+    client = types.SimpleNamespace(sftp=types.SimpleNamespace(listdir=lambda p: []))
+    times = iter([0, 1, 2, 3, 20])
+    monkeypatch.setattr(wf.time, "time", lambda: next(times))
+    with pytest.raises(TimeoutError):
+        wf._find_status_file(client, "dir", 10)
+
+
+def test_fetch_result(tmp_path):
+    class Client:
+        def sftp_get(self, remote, local):
+            Path(local).write_text("data")
+
+    wf._fetch_result(Client(), "/ifs", tmp_path / "file.csv", logging.getLogger(__name__))
+    assert (Path("outputs") / "file_result.csv").exists()
+
+
+def test_fetch_result_warning(caplog, tmp_path):
+    class Client:
+        def sftp_get(self, remote, local):
+            raise RuntimeError("fail")
+
+    with caplog.at_level(logging.WARNING):
+        wf._fetch_result(Client(), "/ifs", tmp_path / "file.csv", logging.getLogger(__name__))
+        assert "Could not fetch result" in caplog.text
+
+
+def test_wait_for_marker_success(monkeypatch, tmp_path):
+    monkeypatch.setattr(wf, "_find_status_file", lambda c, d, e: "ok.status")
+
+    class Client:
+        def __init__(self):
+            self.gets = []
+
+        def sftp_get(self, remote, local):
+            self.gets.append((remote, local))
+            Path(local).write_text("OK")
+
+    fetched = []
+    monkeypatch.setattr(wf, "_fetch_result", lambda c, d, p, l: fetched.append(True))
+    wf._wait_for_marker(Client(), "/ifs", tmp_path / "in.csv", fetch_outputs=True, log=logging.getLogger(__name__), timeout=0)
+    assert fetched
+
+
+def test_wait_for_marker_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(wf, "_find_status_file", lambda c, d, e: "bad.status")
+
+    class Client:
+        def sftp_get(self, remote, local):
+            Path(local).write_text("FAILED cause")
+
+    with pytest.raises(RuntimeError):
+        wf._wait_for_marker(Client(), "/ifs", tmp_path / "in.csv", fetch_outputs=False, log=logging.getLogger(__name__), timeout=0)
+
+
+def test_run_workflow(monkeypatch, tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("a")
+    monkeypatch.setattr(wf, "_prepare_csv", lambda src, log: csv_path)
+    monkeypatch.setattr(wf, "_wait_for_marker", lambda *a, **k: None)
+    actions = []
+
+    class Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def ensure_remote_dirs(self, dirs):
+            actions.append(("dirs", dirs))
+
+        def sftp_put(self, local, remote):
+            actions.append(("put", local, remote))
+
+        def ssh_run(self, cmd):
+            actions.append(("ssh", cmd))
+
+    monkeypatch.setattr(wf, "IBMiClient", lambda cfg, dry_run=False: Client())
+    cfg = types.SimpleNamespace(ifs_dir="/ifs", lib_stg="L", outq="O", jobq="J")
+    wf.run_workflow(csv_path, cfg, sync=False, fetch_outputs=False, timeout=0, dry_run=True)
+    assert any(op[0] == "put" for op in actions)
+
+
+def test_run_workflow_sync(monkeypatch, tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("a")
+    monkeypatch.setattr(wf, "_prepare_csv", lambda src, log: csv_path)
+    monkeypatch.setattr(wf, "_wait_for_marker", lambda *a, **k: None)
+    sync_called = []
+    monkeypatch.setattr(wf, "_sync_scripts", lambda c, d: sync_called.append(d))
+
+    class Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def ensure_remote_dirs(self, dirs):
+            pass
+
+        def sftp_put(self, local, remote):
+            pass
+
+        def ssh_run(self, cmd):
+            pass
+
+    monkeypatch.setattr(wf, "IBMiClient", lambda cfg, dry_run=False: Client())
+    cfg = types.SimpleNamespace(ifs_dir="/ifs", lib_stg="L", outq="O", jobq="J")
+    wf.run_workflow(csv_path, cfg, sync=True, fetch_outputs=False, timeout=0, dry_run=True)
+    assert sync_called == ["/ifs"]
+
+
+def test_teardown(monkeypatch):
+    cmds = []
+
+    class Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            pass
+
+        def ssh_run(self, cmd):
+            cmds.append(cmd)
+
+    monkeypatch.setattr(wf, "IBMiClient", lambda cfg, dry_run=False: Client())
+    cfg = types.SimpleNamespace(ifs_dir="/ifs", lib_stg="L")
+    wf.teardown(cfg, dry_run=True)
+    assert any("teardown.sql" in c for c in cmds)


### PR DESCRIPTION
## Summary
- Add tests for Excel to CSV utility with error handling
- Cover configuration, timing, and CSV utilities
- Test CLI runner and workflow orchestration including GUI buttons

## Testing
- `pytest -q`
- `coverage run -m pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a76d2249088323978a4977fc0b0d9a