### PR TITLE
chore: add DeepSource coverage workflow

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -2,6 +2,11 @@ version = 1
 
 [[analyzers]]
 name = "python"
+enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true

--- a/.github/workflows/deepsource-coverage.yml
+++ b/.github/workflows/deepsource-coverage.yml
@@ -1,0 +1,54 @@
+name: DeepSource Coverage
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=. --cov-report=xml:coverage.xml
+
+      - name: Ensure coverage file size < 20MB
+        run: |
+          [ $(stat -c%s coverage.xml) -le 20000000 ]
+
+      - name: Install DeepSource CLI
+        run: curl https://deepsource.io/cli | sh
+
+      - name: Report to DeepSource
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+        run: |
+          ./bin/deepsource report --analyzer python --coverage-report coverage.xml
+          ./bin/deepsource upload
+
+      # Optional: Use OIDC authentication instead of DSN
+      # - name: Authenticate with DeepSource via OIDC
+      #   uses: deepsourcelabs/oidc-auth@v1
+      # - name: Report to DeepSource (OIDC)
+      #   env:
+      #     DEEPSOURCE_ACCESS_TOKEN: ${{ steps.auth.outputs.token }}
+      #   run: |
+      #     ./bin/deepsource report --analyzer python --coverage-report coverage.xml
+      #     ./bin/deepsource upload

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pandas~=2.2
 black>=24.3.0
 ruff==0.1.5
 mypy==1.5.1
+
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- enable DeepSource python and test-coverage analyzers
- add GitHub Action to run tests and send coverage to DeepSource
- require pytest and pytest-cov for test coverage reporting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76f0e5e348323acb20391e2d10813