### PR TITLE
Guard test iterators against StopIteration

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,14 @@ def test_timed_decorator(monkeypatch, caplog):
     import itertools
 
     counter = itertools.count()
-    monkeypatch.setattr(utils.time, "time", lambda: next(counter))
+
+    def _mock_time():
+        try:
+            return next(counter)
+        except StopIteration:
+            return 0
+
+    monkeypatch.setattr(utils.time, "time", _mock_time)
 
     @utils.timed
     def sample(x):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -68,7 +68,14 @@ def test_find_status_file(monkeypatch):
             return [] if self.calls < 2 else ["done.status"]
 
     times = iter([0, 1, 2])
-    monkeypatch.setattr(wf.time, "time", lambda: next(times))
+
+    def _mock_time():
+        try:
+            return next(times)
+        except StopIteration:
+            return 999
+
+    monkeypatch.setattr(wf.time, "time", _mock_time)
     status = wf._find_status_file(Client(), "dir", 5)
     assert status == "done.status"
 
@@ -76,7 +83,14 @@ def test_find_status_file(monkeypatch):
 def test_find_status_file_timeout(monkeypatch):
     client = types.SimpleNamespace(sftp=types.SimpleNamespace(listdir=lambda p: []))
     times = iter([0, 1, 2, 3, 20])
-    monkeypatch.setattr(wf.time, "time", lambda: next(times))
+
+    def _mock_time():
+        try:
+            return next(times)
+        except StopIteration:
+            return 999
+
+    monkeypatch.setattr(wf.time, "time", _mock_time)
     with pytest.raises(TimeoutError):
         wf._find_status_file(client, "dir", 10)
 


### PR DESCRIPTION
## Summary
- wrap time mocks in tests with StopIteration guards

## Testing
- `pytest tests/test_workflow.py tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7723cd1248323a6a6c72a3207fd5e