### PR TITLE
Add docstrings for mock time helpers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ def test_timed_decorator(monkeypatch, caplog):
     counter = itertools.count()
 
     def _mock_time():
+        """Return sequential timestamps from ``counter`` for testing."""
         try:
             return next(counter)
         except StopIteration:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -70,6 +70,7 @@ def test_find_status_file(monkeypatch):
     times = iter([0, 1, 2])
 
     def _mock_time():
+        """Return sequential timestamps from ``times`` for testing."""
         try:
             return next(times)
         except StopIteration:
@@ -85,6 +86,7 @@ def test_find_status_file_timeout(monkeypatch):
     times = iter([0, 1, 2, 3, 20])
 
     def _mock_time():
+        """Return sequential timestamps from ``times`` for testing."""
         try:
             return next(times)
         except StopIteration:


### PR DESCRIPTION
## Summary
- add docstrings to test `_mock_time` helpers to satisfy documentation linter

## Testing
- `pytest tests/test_workflow.py tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7731dbb4c8323838df942b25193d0